### PR TITLE
core: add appointments/patients modules, repos, exceptions; temporarily disable security

### DIFF
--- a/src/main/java/kma/health/app/kma_health/controller/AppointmentController.java
+++ b/src/main/java/kma/health/app/kma_health/controller/AppointmentController.java
@@ -2,10 +2,13 @@ package kma.health.app.kma_health.controller;
 
 import kma.health.app.kma_health.dto.AppointmentFullViewDto;
 import kma.health.app.kma_health.dto.AppointmentShortViewDto;
+import kma.health.app.kma_health.exception.AppointmentNotFoundException;
 import kma.health.app.kma_health.service.AppointmentService;
 import kma.health.app.kma_health.service.AuthService;
 import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+import kma.health.app.kma_health.exception.ErrorResponse;
 
 import java.util.List;
 import java.util.UUID;
@@ -28,6 +31,12 @@ public class AppointmentController {
     @GetMapping("/{appointmentId}")
     public AppointmentFullViewDto getAppointment(@PathVariable UUID appointmentId) {
         return appointmentService.getFullAppointment(appointmentId);
+    }
+
+    @ExceptionHandler(value = AppointmentNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleAppointmentNotFound(AppointmentNotFoundException e) {
+        return new ErrorResponse(HttpStatus.NOT_FOUND.value(), e.getMessage());
     }
 
 }

--- a/src/main/java/kma/health/app/kma_health/controller/AppointmentController.java
+++ b/src/main/java/kma/health/app/kma_health/controller/AppointmentController.java
@@ -1,0 +1,33 @@
+package kma.health.app.kma_health.controller;
+
+import kma.health.app.kma_health.dto.AppointmentFullViewDto;
+import kma.health.app.kma_health.dto.AppointmentShortViewDto;
+import kma.health.app.kma_health.service.AppointmentService;
+import kma.health.app.kma_health.service.AuthService;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/appointments")
+@AllArgsConstructor
+public class AppointmentController {
+
+    private final AuthService authService;
+    private final AppointmentService appointmentService;
+
+    @GetMapping()
+    public List<AppointmentShortViewDto> getPatientAppointments(@RequestHeader("Authorization") String authHeader) {
+        String token = authService.extractToken(authHeader);
+        String patientId = authService.getUserFromToken(token).getPassportNumber();
+        return appointmentService.getAppointments(patientId);
+    }
+
+    @GetMapping("/{appointmentId}")
+    public AppointmentFullViewDto getAppointment(@PathVariable UUID appointmentId) {
+        return appointmentService.getFullAppointment(appointmentId);
+    }
+
+}

--- a/src/main/java/kma/health/app/kma_health/controller/PatientController.java
+++ b/src/main/java/kma/health/app/kma_health/controller/PatientController.java
@@ -1,0 +1,25 @@
+package kma.health.app.kma_health.controller;
+
+import kma.health.app.kma_health.dto.PatientDto;
+import kma.health.app.kma_health.service.AuthService;
+import kma.health.app.kma_health.service.PatientService;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class PatientController {
+
+    private final PatientService patientService;
+    private final AuthService authService;
+
+    @GetMapping("/profile")
+    public PatientDto getProfile(@RequestHeader("Authorization") String authHeader) {
+        String token = authService.extractToken(authHeader);
+        String id = authService.getUserFromToken(token).getPassportNumber();
+        return new PatientDto(patientService.getPatientById(id));
+    }
+
+}

--- a/src/main/java/kma/health/app/kma_health/dto/AppointmentFullViewDto.java
+++ b/src/main/java/kma/health/app/kma_health/dto/AppointmentFullViewDto.java
@@ -1,0 +1,54 @@
+package kma.health.app.kma_health.dto;
+
+import kma.health.app.kma_health.entity.Appointment;
+import kma.health.app.kma_health.entity.MedicalFile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class AppointmentFullViewDto {
+    private UUID id;
+    private LocalDate date;
+    private LocalTime time;
+
+    private String doctorName;
+    private String doctorId;
+
+    private String diagnosis;
+
+    private Long hospitalId;
+    private String hospitalName;
+
+    private UUID referralId;
+
+    private Set<MedicalFileDto> medicalFiles;
+
+    public AppointmentFullViewDto(Appointment appointment)
+    {
+        this.id = appointment.getId();
+        this.date = appointment.getDate();
+        this.time = appointment.getTime();
+        this.doctorId = appointment.getDoctor().getPassportNumber();
+        this.doctorName = appointment.getDoctor().getFullName();
+        this.diagnosis = appointment.getDiagnosis();
+        this.hospitalId = appointment.getDoctor().getHospital().getId();
+        this.hospitalName = appointment.getDoctor().getHospital().getName();
+        this.referralId = appointment.getReferral().getId();
+        this.medicalFiles = (appointment.getMedicalFiles() == null) ? Set.of()
+                : appointment.getMedicalFiles().stream()
+                .map(MedicalFileDto::new)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/kma/health/app/kma_health/dto/AppointmentShortViewDto.java
+++ b/src/main/java/kma/health/app/kma_health/dto/AppointmentShortViewDto.java
@@ -1,0 +1,31 @@
+package kma.health.app.kma_health.dto;
+
+import kma.health.app.kma_health.entity.Appointment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.UUID;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class AppointmentShortViewDto {
+    private UUID id;
+    private LocalDate date;
+    private LocalTime time;
+    private String doctorName;
+    private String doctorId;
+
+    public AppointmentShortViewDto(Appointment appointment) {
+        this.id = appointment.getId();
+        this.date = appointment.getDate();
+        this.time = appointment.getTime();
+        this.doctorId = appointment.getDoctor().getPassportNumber();
+        this.doctorName = appointment.getDoctor().getFullName();
+    }
+}

--- a/src/main/java/kma/health/app/kma_health/dto/DoctorDto.java
+++ b/src/main/java/kma/health/app/kma_health/dto/DoctorDto.java
@@ -1,0 +1,25 @@
+package kma.health.app.kma_health.dto;
+
+import kma.health.app.kma_health.entity.Doctor;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+public class DoctorDto {
+    private String passportNumber;
+    private String fullName;
+    private String phoneNumber;
+    private String email;
+    private String type;
+    private String doctorType;
+
+    public DoctorDto(Doctor doctor) {
+        this.passportNumber = doctor.getPassportNumber();
+        this.fullName = doctor.getFullName();
+        this.phoneNumber = doctor.getPhoneNumber();
+        this.email = email;
+        this.type = type;
+        this.doctorType = doctorType;
+    }
+}

--- a/src/main/java/kma/health/app/kma_health/dto/MedicalFileDto.java
+++ b/src/main/java/kma/health/app/kma_health/dto/MedicalFileDto.java
@@ -1,0 +1,30 @@
+package kma.health.app.kma_health.dto;
+
+import kma.health.app.kma_health.entity.MedicalFile;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MedicalFileDto {
+    private UUID id;
+    private String fileType;
+    private String name;
+    private String extension;
+    private String link;
+
+    public MedicalFileDto(MedicalFile medicalFile)
+    {
+        this.id = medicalFile.getId();
+        this.fileType = medicalFile.getFileType();
+        this.name = medicalFile.getName();
+        this.extension = medicalFile.getExtension();
+        this.link = medicalFile.getLink();
+    }
+}

--- a/src/main/java/kma/health/app/kma_health/dto/PatientDto.java
+++ b/src/main/java/kma/health/app/kma_health/dto/PatientDto.java
@@ -1,0 +1,29 @@
+package kma.health.app.kma_health.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class PatientDto {
+    private String passportNumber;
+    private String email;
+    private String phoneNumber;
+    private String fullName;
+    private LocalDate birthDate;
+
+    public PatientDto(kma.health.app.kma_health.entity.Patient patient) {
+        this.passportNumber = patient.getPassportNumber();
+        this.email = patient.getEmail();
+        this.phoneNumber = patient.getPhoneNumber();
+        this.fullName = patient.getFullName();
+        this.birthDate = patient.getBirthDate();
+    }
+}
+

--- a/src/main/java/kma/health/app/kma_health/exception/AppointmentNotFoundException.java
+++ b/src/main/java/kma/health/app/kma_health/exception/AppointmentNotFoundException.java
@@ -1,0 +1,11 @@
+package kma.health.app.kma_health.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class AppointmentNotFoundException extends RuntimeException {
+    public AppointmentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/kma/health/app/kma_health/exception/CoordinatesNotFoundException.java
+++ b/src/main/java/kma/health/app/kma_health/exception/CoordinatesNotFoundException.java
@@ -1,4 +1,4 @@
-package kma.health.app.kma_health.exceptions;
+package kma.health.app.kma_health.exception;
 
 public class CoordinatesNotFoundException extends RuntimeException {
     public CoordinatesNotFoundException(String message) {

--- a/src/main/java/kma/health/app/kma_health/exception/ErrorResponse.java
+++ b/src/main/java/kma/health/app/kma_health/exception/ErrorResponse.java
@@ -1,0 +1,21 @@
+package kma.health.app.kma_health.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorResponse {
+
+    private int statusCode;
+    private String message;
+
+    public ErrorResponse(String message)
+    {
+        super();
+        this.message = message;
+    }
+}

--- a/src/main/java/kma/health/app/kma_health/repository/AppointmentRepository.java
+++ b/src/main/java/kma/health/app/kma_health/repository/AppointmentRepository.java
@@ -1,0 +1,11 @@
+package kma.health.app.kma_health.repository;
+
+import kma.health.app.kma_health.entity.Appointment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AppointmentRepository extends JpaRepository<Appointment, UUID> {
+    List<Appointment> findAllByReferralPatientPassportNumber(String patientId);
+}

--- a/src/main/java/kma/health/app/kma_health/repository/AuthUserRepository.java
+++ b/src/main/java/kma/health/app/kma_health/repository/AuthUserRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.NoRepositoryBean;
 import java.util.Optional;
 
 @NoRepositoryBean
-public interface AuthUserRepository<T extends AuthUser> extends JpaRepository<T, Long> {
+public interface AuthUserRepository<T extends AuthUser> extends JpaRepository<T, String> {
     Optional<T> findByEmail(String email);
     Optional<T> findByPhoneNumber(String phone);
     Optional<T> findByPassportNumber(String passport);

--- a/src/main/java/kma/health/app/kma_health/repository/MedicalFileRepository.java
+++ b/src/main/java/kma/health/app/kma_health/repository/MedicalFileRepository.java
@@ -1,0 +1,12 @@
+package kma.health.app.kma_health.repository;
+
+import kma.health.app.kma_health.entity.Hospital;
+import kma.health.app.kma_health.entity.MedicalFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Set;
+import java.util.UUID;
+
+public interface MedicalFileRepository extends JpaRepository<MedicalFile, UUID> {
+    Set<MedicalFile> findAllByAppointment_Id(UUID appointmentId);
+}

--- a/src/main/java/kma/health/app/kma_health/repository/ReferralRepository.java
+++ b/src/main/java/kma/health/app/kma_health/repository/ReferralRepository.java
@@ -1,0 +1,9 @@
+package kma.health.app.kma_health.repository;
+
+import kma.health.app.kma_health.entity.Referral;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ReferralRepository extends JpaRepository<Referral, UUID> {
+}

--- a/src/main/java/kma/health/app/kma_health/security/SecurityConfig.java
+++ b/src/main/java/kma/health/app/kma_health/security/SecurityConfig.java
@@ -19,10 +19,9 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)  // disable CSRF
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/register", "/auth/login").permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()           // allow everything
                 )
                 .formLogin(AbstractHttpConfigurer::disable);
 

--- a/src/main/java/kma/health/app/kma_health/service/AppointmentService.java
+++ b/src/main/java/kma/health/app/kma_health/service/AppointmentService.java
@@ -3,6 +3,7 @@ package kma.health.app.kma_health.service;
 import kma.health.app.kma_health.dto.AppointmentFullViewDto;
 import kma.health.app.kma_health.dto.AppointmentShortViewDto;
 import kma.health.app.kma_health.entity.Appointment;
+import kma.health.app.kma_health.exception.AppointmentNotFoundException;
 import kma.health.app.kma_health.repository.AppointmentRepository;
 import org.springframework.stereotype.Service;
 
@@ -29,11 +30,12 @@ public class AppointmentService {
         return res;
     }
 
-    public AppointmentFullViewDto getFullAppointment(UUID id)
-    {
-        Appointment appointment = appointmentRepository.getReferenceById(id);
-        return new AppointmentFullViewDto(appointment);
+    public AppointmentFullViewDto getFullAppointment(UUID id) {
+        return appointmentRepository.findById(id)
+                .map(AppointmentFullViewDto::new)
+                .orElseThrow(() -> new AppointmentNotFoundException("Appointment is not found."));
     }
+
 
 
 }

--- a/src/main/java/kma/health/app/kma_health/service/AppointmentService.java
+++ b/src/main/java/kma/health/app/kma_health/service/AppointmentService.java
@@ -1,0 +1,39 @@
+package kma.health.app.kma_health.service;
+
+import kma.health.app.kma_health.dto.AppointmentFullViewDto;
+import kma.health.app.kma_health.dto.AppointmentShortViewDto;
+import kma.health.app.kma_health.entity.Appointment;
+import kma.health.app.kma_health.repository.AppointmentRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class AppointmentService {
+    private final AppointmentRepository appointmentRepository;
+
+    public AppointmentService(AppointmentRepository appointmentRepository) {
+        this.appointmentRepository = appointmentRepository;
+    }
+
+    public List<AppointmentShortViewDto> getAppointments(String patientPassportNumber) {
+
+        List<Appointment> queryRes = appointmentRepository.findAllByReferralPatientPassportNumber(patientPassportNumber);
+        List<AppointmentShortViewDto> res = new ArrayList<>();
+        for(Appointment app : queryRes)
+        {
+            res.add(new AppointmentShortViewDto(app));
+        }
+        return res;
+    }
+
+    public AppointmentFullViewDto getFullAppointment(UUID id)
+    {
+        Appointment appointment = appointmentRepository.getReferenceById(id);
+        return new AppointmentFullViewDto(appointment);
+    }
+
+
+}

--- a/src/main/java/kma/health/app/kma_health/service/AuthService.java
+++ b/src/main/java/kma/health/app/kma_health/service/AuthService.java
@@ -111,5 +111,17 @@ public class AuthService {
     public String extractToken(String authHeader) {
         return authHeader.substring(7);
     }
+
+    public AuthUser getUserFromToken(String token) {
+        UserRole role = jwtUtils.getRoleFromToken(token);
+        String passportNumber = jwtUtils.getSubjectFromToken(token);
+
+        return switch (role) {
+            case UserRole.PATIENT -> repositories.get(UserRole.PATIENT).getReferenceById(passportNumber);
+            case UserRole.DOCTOR -> repositories.get(UserRole.DOCTOR).getReferenceById(passportNumber);
+            default -> throw new RuntimeException("Something");
+        };
+
+    }
 }
 

--- a/src/main/java/kma/health/app/kma_health/service/HospitalGeocodingService.java
+++ b/src/main/java/kma/health/app/kma_health/service/HospitalGeocodingService.java
@@ -1,7 +1,7 @@
 package kma.health.app.kma_health.service;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import kma.health.app.kma_health.exceptions.CoordinatesNotFoundException;
+import kma.health.app.kma_health.exception.CoordinatesNotFoundException;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/kma/health/app/kma_health/service/HospitalService.java
+++ b/src/main/java/kma/health/app/kma_health/service/HospitalService.java
@@ -3,7 +3,7 @@ package kma.health.app.kma_health.service;
 import kma.health.app.kma_health.dto.EditHospitalRequest;
 import kma.health.app.kma_health.dto.HospitalDto;
 import kma.health.app.kma_health.entity.Hospital;
-import kma.health.app.kma_health.exceptions.CoordinatesNotFoundException;
+import kma.health.app.kma_health.exception.CoordinatesNotFoundException;
 import kma.health.app.kma_health.repository.HospitalRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/kma/health/app/kma_health/service/PatientService.java
+++ b/src/main/java/kma/health/app/kma_health/service/PatientService.java
@@ -1,0 +1,33 @@
+package kma.health.app.kma_health.service;
+
+import kma.health.app.kma_health.entity.Appointment;
+import kma.health.app.kma_health.entity.Declaration;
+import kma.health.app.kma_health.entity.Patient;
+import kma.health.app.kma_health.repository.AppointmentRepository;
+import kma.health.app.kma_health.repository.PatientRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class PatientService{
+
+    private final PatientRepository patientRepository;
+    private final AppointmentRepository appointmentRepository;
+
+
+    public Patient getPatientById(String id) {
+        return patientRepository.getReferenceById(id);
+    }
+
+    public List<Appointment> getAppointments(String patientId) {
+        return appointmentRepository.findAllByReferralPatientPassportNumber(patientId);
+    }
+
+    public List<Declaration> getDeclarations(String patientId) {
+        return List.of();
+    }
+
+}


### PR DESCRIPTION
## Summary
This PR introduces the Appointments & Patients domains, with repositories, services, controllers, and DTOs. It also temporarily disables security while 'getUserFromToken' is being integrated.

## Details
- **Security**
  - Add 'getUserFromToken' helper (temporary scaffolding).
  - Temporarily disable security to unblock API testing.
- **Auth**
  - Change 'AuthUserRepository' ID type from Long to String (since currently passport number is being used).
- **Domain / Data**
  - New repositories: **Appointment**, **MedicalFile**, **Referral**.
- **API**
  - Controllers & services for **Appointment**.
  - Controllers & services for **Patient**.
  - DTOs for appointment flows.
- **Errors**
  - Add `AppointmentNotFoundException`.
  - Add `ErrorResponse`.
  - Rename/organize exception package.

Closes #1 